### PR TITLE
Don't redundantly specify dependencies in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,12 +1,7 @@
 (source gnu)
 (source melpa)
 
-(package "imgix" "1.0.0" "?")
 (package-file "imgix.el")
 
-(depends-on "ht")
-(depends-on "cask")
-(depends-on "dash")
-(depends-on "f")
-(depends-on "s")
-(depends-on "ert-runner")
+(development
+ (depends-on "ert-runner"))


### PR DESCRIPTION
In connection with https://github.com/milkypostman/melpa/pull/2319
